### PR TITLE
Conform to the latest Web IDL syntax

### DIFF
--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -1485,6 +1485,7 @@
       <dd>Satish Sampath, Google, Inc.</dd>
       <dd>Adam Sobieski, Phoster, Inc.</dd>
       <dd>Raj Tumuluri, Openstream, Inc.</dd>
+      <dd>Kagami Sascha Rosylight</dd>
       <dd>Also, the members of the HTML Speech Incubator Group, and the corresponding Final Report <a href="#ref-1">[1]</a>, created the basis for this specification.</dd>
 
     <h2 class="no-num" id="references">References</h2>

--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -563,20 +563,20 @@
         attribute EventHandler <a href="#dfn-onend">onend</a>;
     };
 
+    enum SpeechRecognitionErrorCode {
+        "<a href="#dfn-sre.nospeech">no-speech</a>",
+        "<a href="#dfn-sre.aborted">aborted</a>",
+        "<a href="#dfn-sre.audiocapture">audio-capture</a>",
+        "<a href="#dfn-sre.network">network</a>",
+        "<a href="#dfn-sre.notallowed">not-allowed</a>",
+        "<a href="#dfn-sre.servicenotallowed">service-not-allowed</a>",
+        "<a href="#dfn-sre.badgrammar">bad-grammar</a>",
+        "<a href="#dfn-sre.languagenotsupported">language-not-supported</a>"
+    };
+
     [Exposed=Window]
     interface <dfn id="speechrecognitionerror">SpeechRecognitionError</dfn> : Event {
-        enum ErrorCode {
-          "<a href="#dfn-sre.nospeech">no-speech</a>",
-          "<a href="#dfn-sre.aborted">aborted</a>",
-          "<a href="#dfn-sre.audiocapture">audio-capture</a>",
-          "<a href="#dfn-sre.network">network</a>",
-          "<a href="#dfn-sre.notallowed">not-allowed</a>",
-          "<a href="#dfn-sre.servicenotallowed">service-not-allowed</a>",
-          "<a href="#dfn-sre.badgrammar">bad-grammar</a>",
-          "<a href="#dfn-sre.languagenotsupported">language-not-supported</a>"
-        };
-
-        readonly attribute ErrorCode <a href="#dfn-error">error</a>;
+        readonly attribute SpeechRecognitionErrorCode <a href="#dfn-error">error</a>;
         readonly attribute DOMString <a href="#dfn-message">message</a>;
     };
 
@@ -985,23 +985,23 @@
         readonly attribute DOMString <a href="#dfn-callbackname">name</a>;
     };
 
+    enum SpeechSynthesisErrorCode {
+        "<a href="#dfn-sse.canceled">canceled</a>",
+        "<a href="#dfn-sse.interrupted">interrupted</a>",
+        "<a href="#dfn-sse.audio-busy">audio-busy</a>",
+        "<a href="#dfn-sse.audio-hardware">audio-hardware</a>",
+        "<a href="#dfn-sse.network">network</a>",
+        "<a href="#dfn-sse.synthesis-unavailable">synthesis-unavailable</a>",
+        "<a href="#dfn-sse.synthesis-failed">synthesis-failed</a>",
+        "<a href="#dfn-sse.language-unavailable">language-unavailable</a>",
+        "<a href="#dfn-sse.voice-unavailable">voice-unavailable</a>",
+        "<a href="#dfn-sse.text-too-long">text-too-long</a>",
+        "<a href="#dfn-sse.invalid-argument">invalid-argument</a>",
+    };
+
     [Exposed=Window]
     interface SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
-        enum ErrorCode {
-            "<a href="#dfn-sse.canceled">canceled</a>",
-            "<a href="#dfn-sse.interrupted">interrupted</a>",
-            "<a href="#dfn-sse.audio-busy">audio-busy</a>",
-            "<a href="#dfn-sse.audio-hardware">audio-hardware</a>",
-            "<a href="#dfn-sse.network">network</a>",
-            "<a href="#dfn-sse.synthesis-unavailable">synthesis-unavailable</a>",
-            "<a href="#dfn-sse.synthesis-failed">synthesis-failed</a>",
-            "<a href="#dfn-sse.language-unavailable">language-unavailable</a>",
-            "<a href="#dfn-sse.voice-unavailable">voice-unavailable</a>",
-            "<a href="#dfn-sse.text-too-long">text-too-long</a>",
-            "<a href="#dfn-sse.invalid-argument">invalid-argument</a>",
-        };
-
-        readonly attribute ErrorCode <a href="#dfn-sse.error">error</a>;
+        readonly attribute SpeechSynthesisErrorCode <a href="#dfn-sse.error">error</a>;
     };
 
     [Exposed=Window]

--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -934,6 +934,7 @@
       <div class="blockContent">
         <pre class="code">
           <code class="idl-code">
+    [Exposed=Window]
     interface SpeechSynthesis : EventTarget {
         readonly attribute boolean <a href="#dfn-ttspending">pending</a>;
         readonly attribute boolean <a href="#dfn-ttsspeaking">speaking</a>;
@@ -956,7 +957,8 @@
 
     Window implements SpeechSynthesisGetter;
 
-    [Constructor,
+    [Exposed=Window,
+     Constructor,
      Constructor(DOMString <a href="#dfn-utterancetext">text</a>)]
     interface SpeechSynthesisUtterance : EventTarget {
         attribute DOMString <a href="#dfn-utterancetext">text</a>;
@@ -975,6 +977,7 @@
         attribute EventHandler <a href="#dfn-utteranceonboundary">onboundary</a>;
     };
 
+    [Exposed=Window]
     interface SpeechSynthesisEvent : Event {
         readonly attribute SpeechSynthesisUtterance <a href="#dfn-callbackutterance">utterance</a>;
         readonly attribute unsigned long <a href="#dfn-callbackcharindex">charIndex</a>;
@@ -982,6 +985,7 @@
         readonly attribute DOMString <a href="#dfn-callbackname">name</a>;
     };
 
+    [Exposed=Window]
     interface SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
         enum ErrorCode {
             "<a href="#dfn-sse.canceled">canceled</a>",
@@ -1000,6 +1004,7 @@
         readonly attribute ErrorCode <a href="#dfn-sse.error">error</a>;
     };
 
+    [Exposed=Window]
     interface SpeechSynthesisVoice {
         readonly attribute DOMString <a href="#dfn-voicevoiceuri">voiceURI</a>;
         readonly attribute DOMString <a href="#dfn-voicename">name</a>;

--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -949,13 +949,10 @@
         sequence&lt;SpeechSynthesisVoiceList&gt; <a href="#dfn-ttsgetvoices">getVoices</a>();
     };
 
-    [NoInterfaceObject]
-    interface SpeechSynthesisGetter
+    partial interface Window
     {
         readonly attribute SpeechSynthesis speechSynthesis;
     };
-
-    Window implements SpeechSynthesisGetter;
 
     [Exposed=Window,
      Constructor,

--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -997,7 +997,7 @@
     };
 
     [Exposed=Window]
-    interface SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
+    interface SpeechSynthesisErrorEvent : SpeechSynthesisEvent {
         readonly attribute SpeechSynthesisErrorCode <a href="#dfn-sse.error">error</a>;
     };
 

--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -343,7 +343,7 @@
       <p><a href="http://www.w3.org/"><img alt=W3C height=48 src="http://www.w3.org/Icons/w3c_home" width=72></a></p>
       <!--end-logo-->
       <h1 id="title_heading">Web Speech API Specification</h1>
-      <h2 class="no-num no-toc" id="draft_date">Editor's Draft: 19 April 2018</h2>
+      <h2 class="no-num no-toc" id="draft_date">Editor's Draft: 11 June 2018</h2>
       <dl>
         <dt>Editors:</dt>
         <dd>Glen Shires, Google Inc.</dd>

--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -946,7 +946,7 @@
         void <a href="#dfn-ttscancel">cancel</a>();
         void <a href="#dfn-ttspause">pause</a>();
         void <a href="#dfn-ttsresume">resume</a>();
-        sequence&lt;SpeechSynthesisVoiceList&gt; <a href="#dfn-ttsgetvoices">getVoices</a>();
+        sequence&lt;SpeechSynthesisVoice&gt; <a href="#dfn-ttsgetvoices">getVoices</a>();
     };
 
     partial interface Window

--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -343,7 +343,7 @@
       <p><a href="http://www.w3.org/"><img alt=W3C height=48 src="http://www.w3.org/Icons/w3c_home" width=72></a></p>
       <!--end-logo-->
       <h1 id="title_heading">Web Speech API Specification</h1>
-      <h2 class="no-num no-toc" id="draft_date">Editor's Draft: 6 June 2014</h2>
+      <h2 class="no-num no-toc" id="draft_date">Editor's Draft: 19 April 2018</h2>
       <dl>
         <dt>Editors:</dt>
         <dd>Glen Shires, Google Inc.</dd>
@@ -534,7 +534,7 @@
       <div class="blockContent">
         <pre class="code">
           <code class="idl-code">
-    [Constructor]
+    [Exposed=Window, Constructor]
     interface <dfn id="dfn-speechreco">SpeechRecognition</dfn> : EventTarget {
         <span class="comment">// recognition parameters</span>
         attribute <a href="#dfn-speechgrammarlist">SpeechGrammarList</a> <a href="#dfn-grammars">grammars</a>;
@@ -563,6 +563,7 @@
         attribute EventHandler <a href="#dfn-onend">onend</a>;
     };
 
+    [Exposed=Window]
     interface <dfn id="speechrecognitionerror">SpeechRecognitionError</dfn> : Event {
         enum ErrorCode {
           "<a href="#dfn-sre.nospeech">no-speech</a>",
@@ -580,12 +581,14 @@
     };
 
     <span class="comment">// Item in N-best list</span>
+    [Exposed=Window]
     interface <dfn id="speechrecognitionalternative">SpeechRecognitionAlternative</dfn> {
         readonly attribute DOMString <a href="#dfn-transcript">transcript</a>;
         readonly attribute float <a href="#dfn-confidence">confidence</a>;
     };
 
     <span class="comment">// A complete one-shot simple response</span>
+    [Exposed=Window]
     interface <dfn id="speechrecognitionresult">SpeechRecognitionResult</dfn> {
         readonly attribute unsigned long <a href="#dfn-length">length</a>;
         getter <a href="#speechrecognitionalternative">SpeechRecognitionAlternative</a> <a href="#dfn-item">item</a>(in unsigned long index);
@@ -593,12 +596,14 @@
     };
 
     <span class="comment">// A collection of responses (used in continuous mode)</span>
+    [Exposed=Window]
     interface <dfn id="speechrecognitionresultlist">SpeechRecognitionResultList</dfn> {
         readonly attribute unsigned long <a href="#dfn-speechrecognitionresultlistlength">length</a>;
         getter <a href="#speechrecognitionresult">SpeechRecognitionResult</a> <a href="#dfn-speechrecognitionresultlistitem">item</a>(in unsigned long index);
     };
 
     <span class="comment">// A full response, which could be interim or final, part of a continuous response or not</span>
+    [Exposed=Window]
     interface <dfn id="speechrecognitionevent">SpeechRecognitionEvent</dfn> : Event {
         readonly attribute unsigned long <a href="#dfn-resultIndex">resultIndex</a>;
         readonly attribute <a href="#speechrecognitionresultlist">SpeechRecognitionResultList</a> <a href="#dfn-results">results</a>;
@@ -607,14 +612,14 @@
     };
 
     <span class="comment">// The object representing a speech grammar</span>
-    [Constructor]
+    [Exposed=Window, Constructor]
     interface <dfn id="dfn-speechgrammar">SpeechGrammar</dfn> {
         attribute DOMString <a href="#dfn-grammarSrc">src</a>;
         attribute float <a href="#dfn-grammarWeight">weight</a>;
     };
 
     <span class="comment">// The object representing a speech grammar collection</span>
-    [Constructor]
+    [Exposed=Window, Constructor]
     interface <dfn id="dfn-speechgrammarlist">SpeechGrammarList</dfn> {
         readonly attribute unsigned long <a href="#dfn-speechgrammarlistlength">length</a>;
         getter <a href="#dfn-speechgrammar">SpeechGrammar</a> <a href="#dfn-speechgrammarlistitem">item</a>(in unsigned long index);


### PR DESCRIPTION
1. [Exposed] extended attribute is now required https://github.com/heycam/webidl/pull/423
2. Nested enum is simply a syntax error
3. `implements` is replaced by interface mixins (https://github.com/heycam/webidl/pull/433), and then [mixins are discouraged if we can write a partial interface](https://heycam.github.io/webidl/#using-mixins-and-partials).