### PR TITLE
Remove use of "in" in IDL

### DIFF
--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -385,7 +385,7 @@
       <li><a href="#speechreco-error"><span class=secno>5.1.4 </span>SpeechRecognitionError</a></li>
       <li><a href="#speechreco-alternative"><span class=secno>5.1.5 </span>SpeechRecognitionAlternative</a></li>
       <li><a href="#speechreco-result"><span class=secno>5.1.6 </span>SpeechRecognitionResult</a></li>
-      <li><a href="#speechreco-resultlist"><span class=secno>5.1.7 </span>SpeechRecognitionList</a></li>
+      <li><a href="#speechreco-resultlist"><span class=secno>5.1.7 </span>SpeechRecognitionResultList</a></li>
       <li><a href="#speechreco-event"><span class=secno>5.1.8 </span>SpeechRecognitionEvent</a></li>
       <li><a href="#speechreco-speechgrammar"><span class=secno>5.1.9 </span>SpeechGrammar</a></li>
       <li><a href="#speechreco-speechgrammarlist"><span class=secno>5.1.10 </span>SpeechGrammarList</a></li>
@@ -829,7 +829,7 @@
       If the value is false, then this represents an interim result that could still be changed.</dd>
     </dl>
 
-    <h4 id="speechreco-resultlist"><span class=secno>5.1.7 </span>SpeechRecognitionList</h4>
+    <h4 id="speechreco-resultlist"><span class=secno>5.1.7 </span>SpeechRecognitionResultList</h4>
 
     <p>The SpeechRecognitionResultList object holds a sequence of recognition results representing the complete return result of a continuous recognition.
     For a non-continuous recognition it will hold only a single value.</p>

--- a/webspeechapi.html
+++ b/webspeechapi.html
@@ -591,7 +591,7 @@
     [Exposed=Window]
     interface <dfn id="speechrecognitionresult">SpeechRecognitionResult</dfn> {
         readonly attribute unsigned long <a href="#dfn-length">length</a>;
-        getter <a href="#speechrecognitionalternative">SpeechRecognitionAlternative</a> <a href="#dfn-item">item</a>(in unsigned long index);
+        getter <a href="#speechrecognitionalternative">SpeechRecognitionAlternative</a> <a href="#dfn-item">item</a>(unsigned long index);
         readonly attribute boolean <a href="#dfn-isFinal">isFinal</a>;
     };
 
@@ -599,7 +599,7 @@
     [Exposed=Window]
     interface <dfn id="speechrecognitionresultlist">SpeechRecognitionResultList</dfn> {
         readonly attribute unsigned long <a href="#dfn-speechrecognitionresultlistlength">length</a>;
-        getter <a href="#speechrecognitionresult">SpeechRecognitionResult</a> <a href="#dfn-speechrecognitionresultlistitem">item</a>(in unsigned long index);
+        getter <a href="#speechrecognitionresult">SpeechRecognitionResult</a> <a href="#dfn-speechrecognitionresultlistitem">item</a>(unsigned long index);
     };
 
     <span class="comment">// A full response, which could be interim or final, part of a continuous response or not</span>
@@ -622,10 +622,10 @@
     [Exposed=Window, Constructor]
     interface <dfn id="dfn-speechgrammarlist">SpeechGrammarList</dfn> {
         readonly attribute unsigned long <a href="#dfn-speechgrammarlistlength">length</a>;
-        getter <a href="#dfn-speechgrammar">SpeechGrammar</a> <a href="#dfn-speechgrammarlistitem">item</a>(in unsigned long index);
-        void <a href="#dfn-addGrammar">addFromURI</a>(in DOMString <a href="#dfn-grammarSrc">src</a>,
+        getter <a href="#dfn-speechgrammar">SpeechGrammar</a> <a href="#dfn-speechgrammarlistitem">item</a>(unsigned long index);
+        void <a href="#dfn-addGrammar">addFromURI</a>(DOMString <a href="#dfn-grammarSrc">src</a>,
                         optional float <a href="#dfn-grammarWeight">weight</a>);
-        void <a href="#dfn-addGrammarstring">addFromString</a>(in DOMString <a href="#dfn-grammarString">string</a>,
+        void <a href="#dfn-addGrammarstring">addFromString</a>(DOMString <a href="#dfn-grammarString">string</a>,
                         optional float <a href="#dfn-grammarWeight">weight</a>);
     };
 
@@ -949,9 +949,8 @@
         sequence&lt;SpeechSynthesisVoice&gt; <a href="#dfn-ttsgetvoices">getVoices</a>();
     };
 
-    partial interface Window
-    {
-        readonly attribute SpeechSynthesis speechSynthesis;
+    partial interface Window {
+        [SameObject] readonly attribute SpeechSynthesis speechSynthesis;
     };
 
     [Exposed=Window,


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=30011.

Drive-by fix: [SameObject] and whitespace.