### PR TITLE
Editorial: fix typos

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -118,7 +118,7 @@ This does not preclude adding support for this as a future API enhancement, and 
   </ul>
   </li>
 
-  <li>The user agent may also give the user a longer explanation the first time speech input is used, to let the user now what it is and how they can tune their privacy settings to disable speech recording if required.</li>
+  <li>The user agent may also give the user a longer explanation the first time speech input is used, to let the user know what it is and how they can tune their privacy settings to disable speech recording if required.</li>
 </ol>
 
 <h3 id="implementation-considerations">Implementation considerations</h3>
@@ -1024,7 +1024,7 @@ These events bubble up to SpeechSynthesis.
 
 <p style="white-space: pre-line">
   Peter Beverloo, Google, Inc.
-  Bjorn Bringert, Google, Inc.
+  Björn Bringert, Google, Inc.
   Gerardo Capiel, Benetech
   Jerry Carter
   Nagesh Kharidi, Openstream, Inc.
@@ -1037,4 +1037,4 @@ These events bubble up to SpeechSynthesis.
   Kagami Sascha Rosylight
 </p>
 
-<p>Also, the members of the HTML Speech Incubator Group, and the corresponding Final Report [[1]], created the basis for this specification.</p>
+<p>Also, the members of the HTML Speech Incubator Group, and the corresponding Final Report [[1]], which created the basis for this specification.</p>


### PR DESCRIPTION
Bjorn isn't really a typo, but Björn is correct:
http://www.cse.chalmers.se/alumni/bringert/