### PR TITLE
Make SpeechSynthesisUtterance's voice attribute nullable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -562,7 +562,7 @@ partial interface Window {
 interface SpeechSynthesisUtterance : EventTarget {
     attribute DOMString text;
     attribute DOMString lang;
-    attribute SpeechSynthesisVoice voice;
+    attribute SpeechSynthesisVoice? voice;
     attribute float volume;
     attribute float rate;
     attribute float pitch;
@@ -690,10 +690,11 @@ interface SpeechSynthesisVoice {
   This default value is computed and used when the input request opens a connection to the recognition service.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisUtterance>voice</dfn> attribute</dt>
-  <dd>The voice attribute specifies speech synthesis voice that the web application wishes to use.
-  If, at the time of the play method call, this attribute has been set to one of the SpeechSynthesisVoice objects returned by getVoices, then the user agent must use that voice.
-  If this attribute is unset or null at the time of the play method call, then the user agent must use a user agent default voice.
-  The user agent default voice should support the current language (see "lang" attribute) and can be a local or remote speech service and can incorporate end user choices via interfaces provided by the user agent such as browser configuration parameters.
+  <dd>This attribute specifies the speech synthesis voice that the web application wishes to use.
+  When a {{SpeechSynthesisUtterance}} object is created this attribute must be initialized to null.
+  If, at the time of the {{speak()}} method call, this attribute has been set to one of the {{SpeechSynthesisVoice}} objects returned by {{getVoices()}}, then the user agent must use that voice.
+  If this attribute is unset or null at the time of the {{speak()}} method call, then the user agent must use a user agent default voice.
+  The user agent default voice should support the current language (see {{SpeechSynthesisUtterance/lang}}) and can be a local or remote speech service and can incorporate end user choices via interfaces provided by the user agent such as browser configuration parameters.
   </dd>
 
   <dt><dfn attribute for=SpeechSynthesisUtterance>volume</dfn> attribute</dt>


### PR DESCRIPTION
Tests: https://github.com/web-platform-tests/wpt/pull/12319

Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=30010.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/pull/22.html" title="Last updated on Aug 6, 2018, 9:59 AM GMT (89f54ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/22/f7dcddd...89f54ff.html" title="Last updated on Aug 6, 2018, 9:59 AM GMT (89f54ff)">Diff</a>