### PR TITLE
Make SpeechRecognitionEvent's emma attribute nullable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -218,7 +218,7 @@ interface SpeechRecognitionEvent : Event {
     readonly attribute unsigned long resultIndex;
     readonly attribute SpeechRecognitionResultList results;
     readonly attribute any interpretation;
-    readonly attribute Document emma;
+    readonly attribute Document? emma;
 };
 
 // The object representing a speech grammar


### PR DESCRIPTION
It is already nullable in Blink and Gecko:
https://chromium.googlesource.com/chromium/src/+/244004461ffaad05ec5daa5eaaccbe0110097642/third_party/blink/renderer/modules/speech/speech_recognition_event.idl
https://github.com/mozilla/gecko-dev/blob/86897859913403b68829dbf9a154f5a87c4b0638/dom/webidl/SpeechRecognitionEvent.webidl

In fact, it always returns null in Blink:
https://chromium.googlesource.com/chromium/src/+/7ad6ea7c2583942e86017bdd6fd5df991f6a05af/third_party/blink/renderer/modules/speech/speech_recognition_event.h#55


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/pull/25.html" title="Last updated on Jun 19, 2018, 11:58 AM GMT (e6437d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/25/b7e0b93...e6437d6.html" title="Last updated on Jun 19, 2018, 11:58 AM GMT (e6437d6)">Diff</a>