### PR TITLE
Add SpeechSynthesisEvent charLength attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -583,6 +583,7 @@ interface SpeechSynthesisUtterance : EventTarget {
 interface SpeechSynthesisEvent : Event {
     readonly attribute SpeechSynthesisUtterance utterance;
     readonly attribute unsigned long charIndex;
+    readonly attribute unsigned long charLength;
     readonly attribute float elapsedTime;
     readonly attribute DOMString name;
 };
@@ -765,6 +766,11 @@ These events bubble up to SpeechSynthesis.
   <dd>This attribute indicates the zero-based character index into the original utterance string that most closely approximates the current speaking position of the speech engine.
   No guarantee is given as to where charIndex will be with respect to word boundaries (such as at the end of the previous word or the beginning of the next word), only that all text before charIndex has already been spoken, and all text after charIndex has not yet been spoken.
   The user agent must return this value if the speech synthesis engine supports it, otherwise the user agent must return undefined.</dd>
+
+  <dt><dfn attribute for=SpeechSynthesisEvent>charLength</dfn> attribute</dt>
+  <dd>This attribute indicates the length of the text (word or sentence) that will be spoken corresponding to this event.
+  This attribute is the length, in characters, starting from this event's {{charIndex}}.
+  The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return undefined.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisEvent>elapsedTime</dfn> attribute</dt>
   <dd>This attribute indicates the time, in seconds, that this event triggered, relative to when this utterance has begun to be spoken.


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=30004.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/pull/30.html" title="Last updated on Aug 6, 2018, 10:45 AM GMT (ca2685e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/30/37047fa...ca2685e.html" title="Last updated on Aug 6, 2018, 10:45 AM GMT (ca2685e)">Diff</a>