### PR TITLE
Add constructors for all event interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -185,10 +185,16 @@ enum SpeechRecognitionErrorCode {
     "language-not-supported"
 };
 
-[Exposed=Window]
+[Exposed=Window,
+ Constructor(DOMString type, SpeechRecognitionErrorEventInit eventInitDict)]
 interface SpeechRecognitionErrorEvent : Event {
     readonly attribute SpeechRecognitionErrorCode error;
     readonly attribute DOMString message;
+};
+
+dictionary SpeechRecognitionErrorEventInit : EventInit {
+    required SpeechRecognitionErrorCode error;
+    DOMString message = "";
 };
 
 // Item in N-best list
@@ -214,12 +220,20 @@ interface SpeechRecognitionResultList {
 };
 
 // A full response, which could be interim or final, part of a continuous response or not
-[Exposed=Window]
+[Exposed=Window,
+ Constructor(DOMString type, SpeechRecognitionEventInit eventInitDict)]
 interface SpeechRecognitionEvent : Event {
     readonly attribute unsigned long resultIndex;
     readonly attribute SpeechRecognitionResultList results;
     readonly attribute any interpretation;
     readonly attribute Document? emma;
+};
+
+dictionary SpeechRecognitionEventInit : EventInit {
+    unsigned long resultIndex = 0;
+    required SpeechRecognitionResultList results;
+    any interpretation = null;
+    Document? emma = null;
 };
 
 // The object representing a speech grammar
@@ -351,7 +365,7 @@ For example, some implementations may fire <a event for=SpeechRecognition>audioe
   <dt><dfn event for=SpeechRecognition>nomatch</dfn> event</dt>
   <dd>Fired when the speech recognizer returns a final result with no recognition hypothesis that meet or exceed the confidence threshold.
   The event must use the {{SpeechRecognitionEvent}} interface.
-  The {{results}} attribute in the event may contain speech recognition results that are below the confidence threshold or may be null.
+  The {{SpeechRecognitionEvent/results}} attribute in the event may contain speech recognition results that are below the confidence threshold or may be null.
   The {{audiostart}} event must always have been fired before the nomatch event.</dd>
 
   <dt><dfn event for=SpeechRecognition>error</dfn> event</dt>
@@ -580,12 +594,20 @@ interface SpeechSynthesisUtterance : EventTarget {
     attribute EventHandler onboundary;
 };
 
-[Exposed=Window]
+[Exposed=Window,
+ Constructor(DOMString type, SpeechSynthesisEventInit eventInitDict)]
 interface SpeechSynthesisEvent : Event {
     readonly attribute SpeechSynthesisUtterance utterance;
     readonly attribute unsigned long charIndex;
     readonly attribute float elapsedTime;
     readonly attribute DOMString name;
+};
+
+dictionary SpeechSynthesisEventInit : EventInit {
+    required SpeechSynthesisUtterance utterance;
+    unsigned long charIndex = 0;
+    float elapsedTime = 0;
+    DOMString name = "";
 };
 
 enum SpeechSynthesisErrorCode {
@@ -603,9 +625,14 @@ enum SpeechSynthesisErrorCode {
     "not-allowed",
 };
 
-[Exposed=Window]
+[Exposed=Window,
+ Constructor(DOMString type, SpeechSynthesisErrorEventInit eventInitDict)]
 interface SpeechSynthesisErrorEvent : SpeechSynthesisEvent {
     readonly attribute SpeechSynthesisErrorCode error;
+};
+
+dictionary SpeechSynthesisErrorEventInit : SpeechSynthesisEventInit {
+    required SpeechSynthesisErrorCode error;
 };
 
 [Exposed=Window]


### PR DESCRIPTION
Fixes https://github.com/w3c/speech-api/issues/14.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/pull/45.html" title="Last updated on Sep 19, 2018, 7:59 AM GMT (01ea11b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/45/5f17cce...01ea11b.html" title="Last updated on Sep 19, 2018, 7:59 AM GMT (01ea11b)">Diff</a>