### PR TITLE
Merge SpeechSynthesisUtterance constructor overloads

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -575,8 +575,7 @@ partial interface Window {
 };
 
 [Exposed=Window,
-  Constructor,
-  Constructor(DOMString text)]
+  Constructor(optional DOMString text)]
 interface SpeechSynthesisUtterance : EventTarget {
     attribute DOMString text;
     attribute DOMString lang;


### PR DESCRIPTION
This old and new IDL is not equivalent because
https://heycam.github.io/webidl/#dfn-overload-resolution-algorithm first
considers the number of arguments, so given one argument the
`Constructor(DOMString text)` overload is used. With optional arguments,
however, trailing undefined arguments are ignored so that `foo(undefined)` will
be indistinguishable from `foo()`.

In other words, the behavior of `new SpeechSynthesisUtterance(undefined)`
changes here, from resulting in a `text` of "undefined" to "".

This in itself doesn't really matter, but if we want to add an init dict for
SpeechSynthesisUtterance it would be optional, and then that would result in
the behavior changing to what this change does.

Tests: https://github.com/web-platform-tests/wpt/pull/13018