### PR TITLE
added charLength to SpeechSynthesisEvent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -598,6 +598,7 @@ interface SpeechSynthesisUtterance : EventTarget {
 interface SpeechSynthesisEvent : Event {
     readonly attribute SpeechSynthesisUtterance utterance;
     readonly attribute unsigned long charIndex;
+    readonly attribute unsigned long charLength;
     readonly attribute float elapsedTime;
     readonly attribute DOMString name;
 };
@@ -605,6 +606,7 @@ interface SpeechSynthesisEvent : Event {
 dictionary SpeechSynthesisEventInit : EventInit {
     required SpeechSynthesisUtterance utterance;
     unsigned long charIndex = 0;
+    unsigned long charLength = 0;
     float elapsedTime = 0;
     DOMString name = "";
 };
@@ -794,6 +796,11 @@ These events bubble up to SpeechSynthesis.
   <dd>This attribute indicates the zero-based character index into the original utterance string that most closely approximates the current speaking position of the speech engine.
   No guarantee is given as to where charIndex will be with respect to word boundaries (such as at the end of the previous word or the beginning of the next word), only that all text before charIndex has already been spoken, and all text after charIndex has not yet been spoken.
   The user agent must return this value if the speech synthesis engine supports it, otherwise the user agent must return undefined.</dd>
+
+  <dt><dfn attribute for=SpeechSynthesisEvent>charLength</dfn> attribute</dt>
+  <dd>This attribute indicates the length of the text (word or sentence) that will be spoken corresponding to this event.
+  This attribute is the length, in characters, starting from this event's {{charIndex}}.
+  The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return undefined.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisEvent>elapsedTime</dfn> attribute</dt>
   <dd>This attribute indicates the time, in seconds, that this event triggered, relative to when this utterance has begun to be spoken.

--- a/index.bs
+++ b/index.bs
@@ -598,7 +598,7 @@ interface SpeechSynthesisUtterance : EventTarget {
 interface SpeechSynthesisEvent : Event {
     readonly attribute SpeechSynthesisUtterance utterance;
     readonly attribute unsigned long charIndex;
-    readonly attribute unsigned long charLength;
+    readonly attribute unsigned long? charLength;
     readonly attribute float elapsedTime;
     readonly attribute DOMString name;
 };
@@ -606,7 +606,7 @@ interface SpeechSynthesisEvent : Event {
 dictionary SpeechSynthesisEventInit : EventInit {
     required SpeechSynthesisUtterance utterance;
     unsigned long charIndex = 0;
-    unsigned long charLength = 0;
+    unsigned long charLength;
     float elapsedTime = 0;
     DOMString name = "";
 };
@@ -800,7 +800,7 @@ These events bubble up to SpeechSynthesis.
   <dt><dfn attribute for=SpeechSynthesisEvent>charLength</dfn> attribute</dt>
   <dd>This attribute indicates the length of the text (word or sentence) that will be spoken corresponding to this event.
   This attribute is the length, in characters, starting from this event's {{charIndex}}.
-  The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return undefined.</dd>
+  The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return null.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisEvent>elapsedTime</dfn> attribute</dt>
   <dd>This attribute indicates the time, in seconds, that this event triggered, relative to when this utterance has begun to be spoken.

--- a/index.bs
+++ b/index.bs
@@ -606,7 +606,7 @@ interface SpeechSynthesisEvent : Event {
 dictionary SpeechSynthesisEventInit : EventInit {
     required SpeechSynthesisUtterance utterance;
     unsigned long charIndex = 0;
-    unsigned long charLength;
+    unsigned long charLength? = null;
     float elapsedTime = 0;
     DOMString name = "";
 };

--- a/index.bs
+++ b/index.bs
@@ -598,7 +598,7 @@ interface SpeechSynthesisUtterance : EventTarget {
 interface SpeechSynthesisEvent : Event {
     readonly attribute SpeechSynthesisUtterance utterance;
     readonly attribute unsigned long charIndex;
-    readonly attribute unsigned long? charLength;
+    readonly attribute unsigned long charLength;
     readonly attribute float elapsedTime;
     readonly attribute DOMString name;
 };
@@ -606,7 +606,7 @@ interface SpeechSynthesisEvent : Event {
 dictionary SpeechSynthesisEventInit : EventInit {
     required SpeechSynthesisUtterance utterance;
     unsigned long charIndex = 0;
-    unsigned long charLength? = null;
+    unsigned long charLength = 0;
     float elapsedTime = 0;
     DOMString name = "";
 };
@@ -795,21 +795,21 @@ These events bubble up to SpeechSynthesis.
   <dt><dfn attribute for=SpeechSynthesisEvent>charIndex</dfn> attribute</dt>
   <dd>This attribute indicates the zero-based character index into the original utterance string that most closely approximates the current speaking position of the speech engine.
   No guarantee is given as to where charIndex will be with respect to word boundaries (such as at the end of the previous word or the beginning of the next word), only that all text before charIndex has already been spoken, and all text after charIndex has not yet been spoken.
-  The user agent must return this value if the speech synthesis engine supports it, otherwise the user agent must return undefined.</dd>
+  The user agent must return this value if the speech synthesis engine supports it, otherwise the user agent must return 0.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisEvent>charLength</dfn> attribute</dt>
   <dd>This attribute indicates the length of the text (word or sentence) that will be spoken corresponding to this event.
   This attribute is the length, in characters, starting from this event's {{charIndex}}.
-  The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return null.</dd>
+  The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return 0.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisEvent>elapsedTime</dfn> attribute</dt>
   <dd>This attribute indicates the time, in seconds, that this event triggered, relative to when this utterance has begun to be spoken.
-  The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return undefined.</dd>
+  The user agent must return this value if the speech synthesis engine supports it or the user agent can otherwise determine it, otherwise the user agent must return 0.</dd>
 
   <dt><dfn attribute for=SpeechSynthesisEvent>name</dfn> attribute</dt>
   <dd>For <a event for=SpeechSynthesisUtterance>mark</a> events, this attribute indicates the name of the marker, as defined in SSML as the name attribute of a mark element. [[!SSML]]
   For <a event for=SpeechSynthesisUtterance>boundary</a> events, this attribute indicates the type of boundary that caused the event: "word" or "sentence".
-  For all other events, this value should return undefined.</dd>
+  For all other events, this value should return "".</dd>
 </dl>
 
 <h4 id="speechsynthesiserrorevent-attributes">SpeechSynthesisErrorEvent Attributes</h4>


### PR DESCRIPTION
There was already a PR about this same concept, but it seems to have become inactive. Creating this PR to get things moving again. Here is the [original discussion](https://www.w3.org/Bugs/Public/show_bug.cgi?id=30004). This change has picked up interest from both Microsoft and Google, so now seems like a good time to make the change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sjdallst/speech-api/pull/50.html" title="Last updated on Mar 15, 2019, 5:49 PM UTC (1a78c87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/50/e3b96a8...sjdallst:1a78c87.html" title="Last updated on Mar 15, 2019, 5:49 PM UTC (1a78c87)">Diff</a>