### PR TITLE
Remove SpeechRecognition's serviceURI attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -153,7 +153,6 @@ interface SpeechRecognition : EventTarget {
     attribute boolean continuous;
     attribute boolean interimResults;
     attribute unsigned long maxAlternatives;
-    attribute DOMString serviceURI;
 
     // methods to drive the speech interaction
     void start();
@@ -283,12 +282,6 @@ interface SpeechGrammarList {
   <dt><dfn attribute for=SpeechRecognition>maxAlternatives</dfn> attribute</dt>
   <dd>This attribute will set the maximum number of {{SpeechRecognitionAlternative}}s per result.
   The default value is 1.</dd>
-
-  <dt><dfn attribute for=SpeechRecognition>serviceURI</dfn> attribute</dt>
-  <dd>The serviceURI attribute specifies the location of the speech recognition service that the web application wishes to use.
-  If this attribute is unset at the time of the start method call, then the user agent must use the user agent default speech service.
-  Note that the serviceURI is a generic URI and can thus point to local services either through use of a URN with meaning to the user agent or by specifying a URL that the user agent recognizes as a local service.
-  Additionally, the user agent default can be local or remote and can incorporate end user choices via interfaces provided by the user agent such as browser configuration parameters.</dd>
 </dl>
 
 <p class=issue>The group has discussed whether WebRTC might be used to specify selection of audio sources and remote recognizers.

--- a/index.bs
+++ b/index.bs
@@ -1058,18 +1058,19 @@ These events bubble up to SpeechSynthesis.
 <h2 class="no-num" id="acknowledgments">Acknowledgments</h2>
 
 <p style="white-space: pre-line">
-  Peter Beverloo, Google, Inc.
-  Björn Bringert, Google, Inc.
-  Gerardo Capiel, Benetech
-  Jerry Carter
-  Nagesh Kharidi, Openstream, Inc.
-  Dominic Mazzoni, Google, Inc.
-  Olli Pettay, Mozilla Foundation
+  Adam Sobieski (Phoster)
+  Björn Bringert (Google)
   Charles Pritchard
-  Satish Sampath, Google, Inc.
-  Adam Sobieski, Phoster, Inc.
-  Raj Tumuluri, Openstream, Inc.
+  Dominic Mazzoni (Google)
+  Gerardo Capiel (Benetech)
+  Jerry Carter
   Kagami Sascha Rosylight
+  Marcos Cáceres (Mozilla)
+  Nagesh Kharidi (Openstream)
+  Olli Pettay (Mozilla)
+  Peter Beverloo (Google)
+  Raj Tumuluri (Openstream)
+  Satish Sampath (Google)
 </p>
 
 <p>Also, the members of the HTML Speech Incubator Group, and the corresponding [[HTMLSPEECH|Final Report]], which created the basis for this specification.</p>


### PR DESCRIPTION
It has not been implemented in any browser engine. If implemented, it
would require a lot more detail around how the browser communicates with
this service.

Test: https://github.com/web-platform-tests/wpt/pull/17848

Fixes https://github.com/w3c/speech-api/issues/52.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/pull/54.html" title="Last updated on Jul 16, 2019, 8:40 AM UTC (7d3cab8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/speech-api/54/959c2ed...7d3cab8.html" title="Last updated on Jul 16, 2019, 8:40 AM UTC (7d3cab8)">Diff</a>