### PR TITLE
Use Web IDL constructor operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -145,8 +145,10 @@ The term "final result" indicates a SpeechRecognitionResult in which the final a
 The term "interim result" indicates a SpeechRecognitionResult in which the final attribute is false.
 
 <pre class="idl">
-[Exposed=Window, Constructor]
+[Exposed=Window]
 interface SpeechRecognition : EventTarget {
+    constructor();
+
     // recognition parameters
     attribute SpeechGrammarList grammars;
     attribute DOMString lang;
@@ -184,9 +186,9 @@ enum SpeechRecognitionErrorCode {
     "language-not-supported"
 };
 
-[Exposed=Window,
- Constructor(DOMString type, SpeechRecognitionErrorEventInit eventInitDict)]
+[Exposed=Window]
 interface SpeechRecognitionErrorEvent : Event {
+    constructor(DOMString type, SpeechRecognitionErrorEventInit eventInitDict);
     readonly attribute SpeechRecognitionErrorCode error;
     readonly attribute DOMString message;
 };
@@ -219,9 +221,9 @@ interface SpeechRecognitionResultList {
 };
 
 // A full response, which could be interim or final, part of a continuous response or not
-[Exposed=Window,
- Constructor(DOMString type, SpeechRecognitionEventInit eventInitDict)]
+[Exposed=Window]
 interface SpeechRecognitionEvent : Event {
+    constructor(DOMString type, SpeechRecognitionEventInit eventInitDict);
     readonly attribute unsigned long resultIndex;
     readonly attribute SpeechRecognitionResultList results;
 };
@@ -239,8 +241,9 @@ interface SpeechGrammar {
 };
 
 // The object representing a speech grammar collection
-[Exposed=Window, Constructor]
+[Exposed=Window]
 interface SpeechGrammarList {
+    constructor();
     readonly attribute unsigned long length;
     getter SpeechGrammar item(unsigned long index);
     void addFromURI(DOMString src,
@@ -547,9 +550,10 @@ partial interface Window {
     [SameObject] readonly attribute SpeechSynthesis speechSynthesis;
 };
 
-[Exposed=Window,
-  Constructor(optional DOMString text)]
+[Exposed=Window]
 interface SpeechSynthesisUtterance : EventTarget {
+    constructor(optional DOMString text);
+
     attribute DOMString text;
     attribute DOMString lang;
     attribute SpeechSynthesisVoice? voice;
@@ -566,9 +570,9 @@ interface SpeechSynthesisUtterance : EventTarget {
     attribute EventHandler onboundary;
 };
 
-[Exposed=Window,
- Constructor(DOMString type, SpeechSynthesisEventInit eventInitDict)]
+[Exposed=Window]
 interface SpeechSynthesisEvent : Event {
+    constructor(DOMString type, SpeechSynthesisEventInit eventInitDict);
     readonly attribute SpeechSynthesisUtterance utterance;
     readonly attribute unsigned long charIndex;
     readonly attribute unsigned long charLength;
@@ -599,9 +603,9 @@ enum SpeechSynthesisErrorCode {
     "not-allowed",
 };
 
-[Exposed=Window,
- Constructor(DOMString type, SpeechSynthesisErrorEventInit eventInitDict)]
+[Exposed=Window]
 interface SpeechSynthesisErrorEvent : SpeechSynthesisEvent {
+    constructor(DOMString type, SpeechSynthesisErrorEventInit eventInitDict);
     readonly attribute SpeechSynthesisErrorCode error;
 };
 


### PR DESCRIPTION
Fixes https://github.com/w3c/speech-api/issues/62.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 29, 2019, 10:09 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fspeech-api%2Faf718189f12d9e6fea6b933269c7480e5c60a598%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/speech-api%2363.)._
</details>
